### PR TITLE
sql.schema.php

### DIFF
--- a/sql/sql.schema.php
+++ b/sql/sql.schema.php
@@ -182,7 +182,7 @@ CREATE TABLE :::subscriber_pending::: (
 CREATE TABLE :::subscribers::: (
   `subscriber_id` int(10) unsigned NOT NULL auto_increment,
   `email` char(60) NOT NULL default '',
-  `time_touched` timestamp(14) NOT NULL,
+  `time_touched` timestamp NOT NULL,
   `time_registered` datetime NOT NULL,
   `flag` tinyint(1) NOT NULL default '0' COMMENT '0: NULL, 1-8: REMOVE, 9: UPDATE',
   `ip` int unsigned NULL default NULL COMMENT 'Stored with INET_ATON(), Fetched with INET_NTOA()',


### PR DESCRIPTION
This is the fix to change timestamp(14) to timestamp.

MySQL 5.5.14 rejects the length attribute
